### PR TITLE
toebeans time fixed

### DIFF
--- a/Assets/Scenes/ToeBeansMinigame.unity
+++ b/Assets/Scenes/ToeBeansMinigame.unity
@@ -1039,6 +1039,87 @@ MonoBehaviour:
   speed: 7.01
   movementOn: 1
   manager: {fileID: 1529948339}
+--- !u!1 &1366867470
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1366867474}
+  - component: {fileID: 1366867473}
+  - component: {fileID: 1366867472}
+  - component: {fileID: 1366867471}
+  m_Layer: 0
+  m_Name: EventSystem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!114 &1366867471
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1366867470}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 1511ccae7919cfc46b603b9b337fdc94, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1366867472
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1366867470}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4f231c4fb786f3946a6b90b886c48677, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_SendPointerHoverToParent: 1
+  m_HorizontalAxis: Horizontal
+  m_VerticalAxis: Vertical
+  m_SubmitButton: Submit
+  m_CancelButton: Cancel
+  m_InputActionsPerSecond: 10
+  m_RepeatDelay: 0.5
+  m_ForceModuleActive: 0
+--- !u!114 &1366867473
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1366867470}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 76c392e42b5098c458856cdf6ecaaaa1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_FirstSelected: {fileID: 0}
+  m_sendNavigationEvents: 1
+  m_DragThreshold: 10
+--- !u!4 &1366867474
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1366867470}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1377687522
 GameObject:
   m_ObjectHideFlags: 0
@@ -1703,3 +1784,4 @@ SceneRoots:
   - {fileID: 1820127410}
   - {fileID: 423909109}
   - {fileID: 801168638}
+  - {fileID: 1366867474}

--- a/Assets/Scripts/Minigames/ToeBeans/BasketScript.cs
+++ b/Assets/Scripts/Minigames/ToeBeans/BasketScript.cs
@@ -33,8 +33,8 @@ public class BasketScript : MonoBehaviour
 
     void MoveBasket()
     {
-        float moveX = Input.GetAxis("Horizontal");
-        // Debug.Log("MOVEX: " + moveX);
+        float moveX = Input.GetAxisRaw("Horizontal");
+        Debug.Log("MOVEX: " + moveX);
         float newX = transform.position.x + (moveX * speed * Time.unscaledDeltaTime);
 
         // Clamp position to stay within bounds

--- a/Assets/Scripts/Minigames/ToeBeans/CatchGame.cs
+++ b/Assets/Scripts/Minigames/ToeBeans/CatchGame.cs
@@ -15,13 +15,15 @@ public class CatchGame : BaseMinigame
         Debug.Log("Unloaded Scene: " + SceneManager.GetActiveScene().name);
         SceneManager.UnloadSceneAsync(s);
         curScore = 0;
-        UnpauseMainScene();
+        // UnpauseMainScene();
+        Time.timeScale = 1f;
         enabled = false;
     }
 
     public override void StartGame()
     {
-        PauseMainScene();
+        // PauseMainScene();
+        Time.timeScale = 0f;
         StartCoroutine(StartGameCoroutine());
     }
 

--- a/Assets/Scripts/Minigames/ToeBeans/ToeBeansMinigame.cs
+++ b/Assets/Scripts/Minigames/ToeBeans/ToeBeansMinigame.cs
@@ -21,6 +21,7 @@ public class ToeBeansMinigame : MonoBehaviour
     void Awake()
     {
         catchGame = FindObjectOfType<CatchGame>();
+        Physics2D.simulationMode = SimulationMode2D.Script;
         ResetGame();
     }
     void Start()
@@ -47,6 +48,7 @@ public class ToeBeansMinigame : MonoBehaviour
 
             if (timer >= gameTime)
             {
+                gameOver = true;
                 catchGame.GameOver();
             }
         }
@@ -56,6 +58,8 @@ public class ToeBeansMinigame : MonoBehaviour
         {
             ResetGame();
         }
+
+        Physics2D.Simulate(Time.unscaledDeltaTime);
     }
 
     void ResetGame()


### PR DESCRIPTION
Time was still moving because I tried to stop all gameobjects by converting their physics rigid bodies to kinematic, but that didn't stop the gamemanager from moving time.  And the reason I tried was because colliders don't work when time is paused because all physics are paused. 

The solution:
- In the minigame manager, call ``` Physics2D.simulationMode = SimulationMode2D.Script;``` inside of the awake function to set physics to simulate manually instead of based on time. Then, in the update function, call ```Physics2D.Simulate(Time.unscaledDeltaTime);``` to simulate physics using unscaledDeltaTime. This will start to simulate physics based on Time.unscaledDeltaTime. Then use unscaledDeltaTime in your other scripts instead of deltaTime.